### PR TITLE
Checking if user exists before handling customer.subscription.deleted

### DIFF
--- a/app/controllers/stripe_controller.rb
+++ b/app/controllers/stripe_controller.rb
@@ -45,11 +45,13 @@ class StripeController < ApplicationController
 
     when "customer.subscription.deleted"
       #after three failed payment attempts as per the settings subscription will be deleted
-      user.subscription_id = nil
-      user.is_active = false
-      user.save!
-      StripeCustomer.delete_all_sources(user)
-      SubscriptionMailer.delay.customer_subscription_deleted(user)
+      if user
+        user.subscription_id = nil
+        user.is_active = false
+        user.save!
+        StripeCustomer.delete_all_sources(user)
+        SubscriptionMailer.delay.customer_subscription_deleted(user)
+      end
 
     when "customer.subscription.updated"
       #to capture subscription from trial to active

--- a/spec/controllers/stripe_controller_spec.rb
+++ b/spec/controllers/stripe_controller_spec.rb
@@ -1,5 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe StripeController, type: :controller do
-
+    let(:payload) { File.read("spec/support/stripe/evt_customer_subscription_deleted.json") }
+  it 'respond to stripe event' do
+    expect(Thread).to receive(:new).and_yield
+    post :events, payload
+    expect(response.status).to eq 200
+  end
 end

--- a/spec/support/stripe/evt_customer_subscription_deleted.json
+++ b/spec/support/stripe/evt_customer_subscription_deleted.json
@@ -1,0 +1,94 @@
+{
+  "id": "evt_1ccte7dydcromj6ppiy1zwgb",
+  "type": "customer.subscription.deleted",
+  "data": {
+    "object": {
+      "id": "sub_CRMQ3P8idLYVi8",
+      "object": "subscription",
+      "application_fee_percent": null,
+      "billing": "charge_automatically",
+      "billing_cycle_anchor": 1522972800,
+      "cancel_at_period_end": false,
+      "canceled_at": 1522779255,
+      "created": 1520296220,
+      "current_period_end": 1522972800,
+      "current_period_start": 1520296220,
+      "customer": "cus_CRMQBJw5gvc2RF",
+      "days_until_due": null,
+      "discount": null,
+      "ended_at": 1522779255,
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_CRMQKgEqGyR8RK",
+            "object": "subscription_item",
+            "created": 1520296221,
+            "metadata": {
+            },
+            "plan": {
+              "id": "monthly",
+              "object": "plan",
+              "amount": 900,
+              "billing_scheme": "per_unit",
+              "created": 1504027263,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": true,
+              "metadata": {
+              },
+              "nickname": null,
+              "product": "prod_BUmMe4Utr1P60F",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed",
+              "statement_descriptor": null,
+              "name": "Monthly"
+            },
+            "quantity": 1,
+            "subscription": "sub_CRMQ3P8idLYVi8"
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_CRMQ3P8idLYVi8"
+      },
+      "livemode": true,
+      "metadata": {
+        "automatic": "true"
+      },
+      "plan": {
+        "id": "monthly",
+        "object": "plan",
+        "amount": 900,
+        "billing_scheme": "per_unit",
+        "created": 1504027263,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": true,
+        "metadata": {
+        },
+        "nickname": null,
+        "product": "prod_BUmMe4Utr1P60F",
+        "tiers": null,
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed",
+        "statement_descriptor": null,
+        "name": "Monthly"
+      },
+      "quantity": 1,
+      "start": 1520296220,
+      "status": "canceled",
+      "tax_percent": null,
+      "trial_end": 1522972800,
+      "trial_start": 1520296220
+    },
+    "previous_attributes": null
+  }
+}


### PR DESCRIPTION
When a user is deleted by an admin after the user is deleted on Stripe, `customer.subscription.deleted` is fired by Stripe

Resolves #184 